### PR TITLE
Reduce the Flatpak size and more

### DIFF
--- a/org.kde.kid3.json
+++ b/org.kde.kid3.json
@@ -19,10 +19,13 @@
     ],
     "cleanup": [
         "/man",
+        "/share/doc",
         "/share/man",
         "/include",
         "/lib/*.a",
         "/lib/*.la",
+        "/lib/cmake",
+        "/lib/pkgconfig",
         "/share/**/*-qt.*",
         "/share/icons/**/**/**/*-qt.*"
     ],

--- a/org.kde.kid3.json
+++ b/org.kde.kid3.json
@@ -61,6 +61,9 @@
                 "-DKDE_SKIP_TEST_SETTINGS=ON",
                 "-DBUILD_WITH_QT6=ON"
             ],
+            "post-install": [
+                "gunzip -S z /app/share/icons/hicolor/scalable/apps/kid3.svgz"
+            ],
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
### Reduce the Flatpak size

The installed size reduced from 15.3 MB to 10.0 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.

### Convert svgz icon to svg
